### PR TITLE
Add indentScript config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dprint, then:
 | Key              | Default | Description                                |
 | ---------------- | ------- | ------------------------------------------ |
 | `indentTemplate` | `true`  | Indent the content of the `<template>` tag |
-| `indentScript`   | `false` | Indent the content of the `<script>` tag |
+| `indentScript`   | `false` | Indent the content of the `<script>` tag   |
 | `indentWidth`    | `2`     | Width of the indentation                   |
 | `useTabs`        | `false` | Use tabs for indentation                   |
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ dprint, then:
 | Key              | Default | Description                                |
 | ---------------- | ------- | ------------------------------------------ |
 | `indentTemplate` | `true`  | Indent the content of the `<template>` tag |
+| `indentScript`   | `false` | Indent the content of the `<script>` tag |
 | `indentWidth`    | `2`     | Width of the indentation                   |
 | `useTabs`        | `false` | Use tabs for indentation                   |
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct Configuration {
     pub indent_template: bool,
+    pub indent_script: bool,
     pub use_tabs: bool,
     pub indent_width: u8,
 }
@@ -18,6 +19,7 @@ impl Default for Configuration {
     fn default() -> Self {
         Self {
             indent_template: true,
+            indent_script: false,
             use_tabs: RECOMMENDED_GLOBAL_CONFIGURATION.use_tabs,
             indent_width: RECOMMENDED_GLOBAL_CONFIGURATION.indent_width,
         }
@@ -33,6 +35,7 @@ impl Configuration {
 
         let resolved_config = Configuration {
             indent_template: get_value(&mut config, "indentTemplate", true, &mut diagnostics),
+            indent_script: get_value(&mut config, "indentScript", false, &mut diagnostics),
             use_tabs: get_value(
                 &mut config,
                 "useTabs",

--- a/src/format.rs
+++ b/src/format.rs
@@ -86,6 +86,8 @@ fn format_block<'a>(
             let desired_indent_width =
                 if block.name.as_str() == "template" && config.indent_template {
                     usize::from(config.indent_width)
+                } else if block.name.as_str() == "script" && config.indent_script {
+                    usize::from(config.indent_width)
                 } else {
                     0
                 };


### PR DESCRIPTION
Intended to close issue #9

The option defaults to false, to preserve the same behavior for older config files.

I manually tested this on a codebase I'm hoping to use dprint with and the behavior was as intended.
